### PR TITLE
Fix lint issues in MainActivity.kt

### DIFF
--- a/app/androidApp/src/main/java/tt/co/jesses/moonlight/android/app/MainActivity.kt
+++ b/app/androidApp/src/main/java/tt/co/jesses/moonlight/android/app/MainActivity.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
@@ -52,7 +51,7 @@ class MainActivity : ComponentActivity() {
                     val scaffoldState = rememberScaffoldState()
                     val viewModel: MoonlightViewModel = viewModel()
                     val pagerState = rememberPagerState(
-                        pageCount = { Screens.values().size },
+                        pageCount = { Screens.entries.size },
                         initialPage = 0,
                     )
                     val hasSwiped by viewModel.hasSwiped.collectAsState(initial = false)


### PR DESCRIPTION
This PR addresses two specific lint issues identified in `MainActivity.kt`:
1. It removes an unused import that was cluttering the file.
2. It migrates from the legacy `values()` method on the `Screens` enum to the newer `entries` property introduced in Kotlin 1.9.0. This optimization avoids array allocation on every access, which is the recommended approach for performance and readability.

Fixes #93

---
*PR created automatically by Jules for task [15934058740003085136](https://jules.google.com/task/15934058740003085136) started by @JesseScott*