### PR TITLE
Implement basic localization for Spanish (es)

### DIFF
--- a/app/androidApp/src/main/java/tt/co/jesses/moonlight/android/view/AboutScreen.kt
+++ b/app/androidApp/src/main/java/tt/co/jesses/moonlight/android/view/AboutScreen.kt
@@ -277,7 +277,7 @@ fun AboutScreen(
                 Text(
                     text = buildAnnotatedString {
                         withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append("Version: ")
+                            append(stringResource(R.string.credits_info_version_label))
                         }
                         append(versionInfo)
                     },

--- a/app/androidApp/src/main/res/values-es/strings.xml
+++ b/app/androidApp/src/main/res/values-es/strings.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app">moonlight</string>
+
+    <!-- Screens -->
+    <string name="title_moon">luna</string>
+    <string name="title_data">datos</string>
+    <string name="title_about">info</string>
+
+    <string name="swipe_to_see_more">Desliza para ver más</string>
+
+    <!-- Data -->
+    <string name="data_fraction">Fracción</string>
+    <string name="data_phase">Fase</string>
+    <string name="data_angle">Ángulo</string>
+    <string name="data_azimuth">Azimut</string>
+    <string name="data_altitude">Altitud</string>
+    <string name="data_distance">Distancia</string>
+    <string name="data_parallactic_angle">Ángulo Paraláctico</string>
+    <string name="data_description">
+        Los datos anteriores son una representación en tiempo real del estado actual de la luna. Los datos se utilizan como un algoritmo para generar un degradado personalizado.
+        \n\nEl tono del degradado se obtiene mapeando la fase actual, que comienza en -180.0 (luna nueva, creciente), pasa por 0.0 (luna llena) y se mueve hacia 180.0 (menguante, luna nueva).
+        \n\nLa saturación está impulsada por la altitud: 0.0 significa que el centro de la luna está en el horizonte, 90.0 en el cenit (directamente sobre su cabeza).
+        \n\nLa luminosidad se deriva del ángulo de iluminación de la luna en relación con la tierra. La luna es creciente si el ángulo es negativo y menguante si es positivo.
+        \n\nEl alfa del degradado se extrae de la fracción iluminada de la luna: .0 indica luna nueva, 1.0 indica luna llena.
+    </string>
+
+    <!-- Analytics -->
+    <string name="analytics_consent_title">Consentimiento de analíticas</string>
+    <string name="analytics_consent_body">Para ayudarnos a mejorar su experiencia con la aplicación, nos gustaría recopilar datos de uso anónimos. Su privacidad es importante para nosotros y no se recopilará ni compartirá ninguna información de identificación personal.</string>
+    <string name="analytics_action_enable">Habilitar</string>
+    <string name="analytics_action_disable">Deshabilitar</string>
+
+    <!-- Credits -->
+    <string name="credits_made_by_full">moonlight fue desarrollado por el artista Jesse Scott y se inspiró originalmente en una idea de la artista Kelly Andres.</string>
+    <string name="credits_made_by_key">Jesse Scott</string>
+    <string name="credits_made_by_value">http://jesses.co.tt</string>
+    <string name="credits_inspired_by_key">Kelly Andres</string>
+    <string name="credits_inspired_by_value">https://kellyandres.xyz</string>
+
+    <string name="credits_source_full">
+        moonlight es una aplicación de código abierto.
+        \n\nEl código se puede encontrar en GitHub y a continuación se muestra una lista de todas las bibliotecas utilizadas en este proyecto.
+        Un agradecimiento especial a SunCalc, sin el cual este proyecto no sería posible.
+    </string>
+    <string name="credits_source_key">GitHub</string>
+    <string name="credits_source_value">https://github.com/JesseScott/moonlight</string>
+    <string name="credits_suncalc_key">SunCalc</string>
+    <string name="credits_suncalc_value">https://github.com/shred/commons-suncalc</string>
+
+    <string name="credits_credits_header">créditos</string>
+    <string name="credits_ack_header">agradecimientos</string>
+    <string name="credits_oss">Licencias de código abierto</string>
+    <string name="credits_info_header">información</string>
+
+    <string name="credits_info_version">Versión %s</string>
+    <string name="credits_info_version_label">Versión: </string>
+
+    <string name="credits_info_feedback">Comentarios</string>
+    <string name="credits_info_feedback_message">¡Envíeme sus comentarios, preguntas o inquietudes!</string>
+    <string name="credits_info_feedback_action">enviar</string>
+    <string name="credits_info_feedback_action_url">https://workable-zydeco-5d0.notion.site/3171a41696ff80fdb7a8d43084bb74cb?pvs=105</string>
+
+    <string name="credits_info_coffee">Cómprame un café</string>
+    <string name="credits_info_coffee_message">Este proyecto es un trabajo de amor. Si puede y está dispuesto a apoyar mi trabajo, cómpreme un café.</string>
+    <string name="credits_info_coffee_action">apoyar</string>
+    <string name="credits_info_coffee_action_url">https://ko-fi.com/jessescott</string>
+</resources>

--- a/app/androidApp/src/main/res/values/strings.xml
+++ b/app/androidApp/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="credits_info_header">info</string>
 
     <string name="credits_info_version">Version %s</string>
+    <string name="credits_info_version_label">Version: </string>
 
     <string name="credits_info_feedback">Feedback</string>
     <string name="credits_info_feedback_message">Send me your feedback, questions, or concerns!</string>

--- a/app/common/src/main/res/values-es/strings.xml
+++ b/app/common/src/main/res/values-es/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Data -->
+    <string name="data_fraction">Fracción</string>
+    <string name="data_phase">Fase</string>
+    <string name="data_angle">Ángulo</string>
+    <string name="data_azimuth">Azimut</string>
+    <string name="data_altitude">Altitud</string>
+    <string name="data_distance">Distancia</string>
+    <string name="data_parallactic_angle">Ángulo Paraláctico</string>
+</resources>

--- a/app/wearApp/src/main/res/values-es/strings.xml
+++ b/app/wearApp/src/main/res/values-es/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Moonlight Wear</string>
+</resources>

--- a/app/widget/src/main/java/tt/co/jesses/moonlight/widget/MoonlightWidget.kt
+++ b/app/widget/src/main/java/tt/co/jesses/moonlight/widget/MoonlightWidget.kt
@@ -14,6 +14,7 @@ import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.text.Text
+import tt.co.jesses.moonlight.widget.R
 import tt.co.jesses.moonlight.common.util.GradientUtil
 import tt.co.jesses.moonlight.common.util.drawAngledGradient
 
@@ -43,9 +44,9 @@ class MoonlightWidget : GlanceAppWidget() {
         ) {
             Image(
                 provider = BitmapImageProvider(bitmap),
-                contentDescription = "Moonlight gradient background",
+                contentDescription = context.getString(R.string.widget_content_description),
             )
-            Text("Moonlight Widget")
+            Text(context.getString(R.string.widget_name))
         }
     }
 }

--- a/app/widget/src/main/res/values-es/strings.xml
+++ b/app/widget/src/main/res/values-es/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="wallpaper_name">moonlight</string>
+    <string name="widget_name">Widget de Moonlight</string>
+    <string name="widget_content_description">Fondo degradado de Moonlight</string>
+</resources>

--- a/app/widget/src/main/res/values/strings.xml
+++ b/app/widget/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="wallpaper_name">moonlight</string>
+    <string name="widget_name">Moonlight Widget</string>
+    <string name="widget_content_description">Moonlight gradient background</string>
 </resources>


### PR DESCRIPTION
This change introduces basic localization for Spanish (es) to the Moonlight application. It involves adding `values-es/strings.xml` files to the `androidApp`, `common`, `wearApp`, and `widget` modules with translations for all user-facing strings. Additionally, hardcoded strings in the `AboutScreen` and the `MoonlightWidget` have been moved to the appropriate `strings.xml` files to ensure they can be localized.

The translations cover:
- Main app screens (Moon, Data, About)
- Technical data descriptions and labels
- Analytics consent dialog
- Credits and acknowledgments
- Version information
- Feedback and support actions

The changes follow standard Android localization practices and ensure a consistent experience for Spanish-speaking users across different app variants (Phone, Wear OS, Widgets).

Fixes #18

---
*PR created automatically by Jules for task [11762267838381275812](https://jules.google.com/task/11762267838381275812) started by @JesseScott*