### PR TITLE
Ignore disabled Kotlin/Native targets during CI builds

### DIFF
--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -31,3 +31,4 @@ android.nonTransitiveRClass=true
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.mpp.androidGradlePluginCompatibility.nowarn=false
+kotlin.native.ignoreDisabledTargets=true


### PR DESCRIPTION
The CI builds were showing warnings about disabled Kotlin/Native targets that cannot be built on Linux hosts (e.g., iosX64, iosArm64). This change adds `kotlin.native.ignoreDisabledTargets=true` to the root `gradle.properties` file as recommended by the Gradle error message to hide these warnings.

Fixes #100

---
*PR created automatically by Jules for task [1579604964706035699](https://jules.google.com/task/1579604964706035699) started by @JesseScott*