### PR TITLE
Resolve KMP android target deprecation warning in shared module

### DIFF
--- a/app/shared/build.gradle.kts
+++ b/app/shared/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    android {
+    androidTarget {
         compilations.all {
             kotlinOptions {
                 jvmTarget = "1.8"


### PR DESCRIPTION
The `android` target configuration in Kotlin Multiplatform was deprecated in favor of `androidTarget`. This PR updates the `:shared` module's `build.gradle.kts` to use the new DSL, resolving a CI warning and ensuring compatibility with future Kotlin versions. Verified with a local build of the shared module and confirmed the warning is no longer present.

Fixes #103

---
*PR created automatically by Jules for task [3585007491029706952](https://jules.google.com/task/3585007491029706952) started by @JesseScott*