### PR TITLE
Resolve androidx.vectordrawable namespace clash

### DIFF
--- a/app/androidApp/build.gradle.kts
+++ b/app/androidApp/build.gradle.kts
@@ -51,6 +51,11 @@ android {
 }
 
 dependencies {
+    constraints {
+        implementation("androidx.vectordrawable:vectordrawable:1.1.0")
+        implementation("androidx.vectordrawable:vectordrawable-animated:1.1.0")
+    }
+
     implementation(project(":shared"))
     implementation(project(":common"))
 


### PR DESCRIPTION
Resolved a namespace collision between `androidx.vectordrawable:vectordrawable` and `androidx.vectordrawable:vectordrawable-animated` (version 1.0.0) that was causing build warnings/errors in CI. The fix uses Gradle dependency constraints in the `:androidApp` module to force these libraries to version 1.1.0, which uses unique namespaces. Verified the upgrade via dependency reports and confirmed that the `:androidApp:processDebugMainManifest` task now completes without warnings.

Fixes #101

---
*PR created automatically by Jules for task [14774104355877295410](https://jules.google.com/task/14774104355877295410) started by @JesseScott*