### PR TITLE
feat: use different refresh cycle duration for Debug builds

### DIFF
--- a/app/androidApp/src/main/java/tt/co/jesses/moonlight/android/view/state/MoonlightViewModel.kt
+++ b/app/androidApp/src/main/java/tt/co/jesses/moonlight/android/view/state/MoonlightViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import tt.co.jesses.moonlight.common.data.model.AnalyticsAcceptance
 import tt.co.jesses.moonlight.common.data.repository.MoonlightRepository
 import tt.co.jesses.moonlight.common.data.repository.UserPreferencesRepository
+import tt.co.jesses.moonlight.android.BuildConfig
 import javax.inject.Inject
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -28,7 +29,11 @@ class MoonlightViewModel @Inject constructor(
 
     val refreshCycle: Duration
         get() {
-            return 30.seconds // todo figure out Debug flag
+            return if (BuildConfig.DEBUG) {
+                5.seconds
+            } else {
+                30.seconds
+            }
         }
 
     init {

--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,5 +1,5 @@
 ### Gradle
-org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
 
 # When set to true, Gradle will try to reuse outputs from previous builds
 org.gradle.caching=true


### PR DESCRIPTION
Configure Debug Refresh Cycle

* Modified `MoonlightViewModel.kt` to use `BuildConfig.DEBUG`.
* If true, `refreshCycle` is set to `5.seconds`.
* Otherwise, `refreshCycle` is set to `30.seconds`.
* Addressed `IllegalAccessError` with `KaptJavaCompiler` by adding `--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED` to `gradle.properties`.

---
*PR created automatically by Jules for task [401863735772452460](https://jules.google.com/task/401863735772452460) started by @JesseScott*